### PR TITLE
Authoritative Server Patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ nimblecache/
 htmldocs/
 server
 client
+*.exe

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # nettyrpc
-Implements an RPC like system using netty.
+ Implements an RPC-like system for Nim
+
+nettyrpc is an RPC library built on top of the netty library, and sends data over a modified UDP connection that's capped at 250kb of in-flight data.  Netty performs packet ordering and packet resending like a TCP connection.  Check the netty library for more information about how netty utilizes UDP, and it's limitations.
+
+nettyrpc can be set up to run authoritative and non-authoritative servers by the use of `{.networked.}` or `{.relayed.}` RPCs. 
+
+A relayed RPC is sent directly to the server, no server-side processing is done and the RPC is sent to every connected client on the server where it is processed client-side.  Relayed RPCs have a `isLocal` bool that can be used to control what the caller runs in a relayed procedure vs what the receivers runs.  Relayed procedures can be called like any other procedure.
+
+Networked RPCs are sent to the server where the server processes the data, and depending on how you write your server code, the server can forward the data to an individual client, all clients, or process the data server-side without any forwarding.  Networked RPCs must be called through the `rpc` procedures provided by nettyrpc.
+
+Both relayed and networked RPCs contain a netty `Connection` object that represents the RPC caller's connection.  This is accessed through the `conn` variable that is automatically added to any `{.relayed.}` or `{.networked.}` procedures.
+
+## Uses
+
+Mostly games, but any networked application that does not require a ton of throughput.  UDP is not designed for throughput, however this library could be used to negotiate a TCP connection for larger data transfers.
+
+## Examples
+
+Check the examples folder in this repo for documented examples.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ nettyrpc can be set up to run authoritative and non-authoritative servers by the
 
 A `{.relayed.}` RPC is sent directly to the server, no server-side processing is done and the RPC is sent to every connected client on the server where it is processed client-side.  Relayed RPCs have a `isLocal` bool that can be used to control what the caller runs in a relayed procedure vs what the receivers run.  Unlike `{.networked.}` procedures, relayed procedures can be called like any other procedure.
 
-`{.networked.}` RPCs are sent to the server where the server processes the data, and depending on how you write your server code, the server can forward the data to an individual client, all clients, or process the data server-side without any forwarding.  Networked RPCs must be called through the `rpc` procedures provided by nettyrpc, ie. `rpc("someRemoteProc", (arg1, arg2, arg3))` or `rpc(conn, "someRemoteProc", (arg1, arg2, arg3))`.  It's important that your arguments are contained within a `tuple`.
+`{.networked.}` RPCs are sent to the server where the server processes the data, and depending on how you write your server code, the server can forward the data to an individual client, all clients, or process the data server-side without any forwarding.  Networked RPCs must be called through the `rpc` procedures provided by nettyrpc, ie. `rpc("someRemoteProc", (arg1, arg2, arg3))` or `rpc(conn, "someRemoteProc", (arg1, arg2, arg3))`.  It's important that your args are wrapped in a `tuple` when using the `rpc` procedures.
 
 Both relayed and networked RPCs contain a netty `Connection` object that represents the RPC caller's connection.  This is accessed through the `conn` variable that is automatically added to any `{.relayed.}` or `{.networked.}` procedures.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ while true:
   client.rpcTick()  
 ```
 
-Here is the server code we need to handle the call to `join`, and then calling the `welcome` procedure on each connected client.
+Here is the server code we need to handle the call to `join`, and then calling the `welcome` procedure on each connected client.  It also sends the same welcome message to the caller of the RPC (to demonstrate direct calling of a RP)
 
 __server.nim__
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://github.com/treeform/netty
 
 nettyrpc can be set up to run authoritative and non-authoritative servers by the use of `{.networked.}` or `{.relayed.}` procedures. 
 
-A relayed RPC is sent directly to the server, no server-side processing is done and the RPC is sent to every connected client on the server where it is processed client-side.  Relayed RPCs have a `isLocal` bool that can be used to control what the caller runs in a relayed procedure vs what the receivers run.  Unlike networked procedures, relayed procedures can be called like any other procedure.
+A `{.relayed.}` RPC is sent directly to the server, no server-side processing is done and the RPC is sent to every connected client on the server where it is processed client-side.  Relayed RPCs have a `isLocal` bool that can be used to control what the caller runs in a relayed procedure vs what the receivers run.  Unlike `{.networked.}` procedures, relayed procedures can be called like any other procedure.
 
 Networked RPCs are sent to the server where the server processes the data, and depending on how you write your server code, the server can forward the data to an individual client, all clients, or process the data server-side without any forwarding.  Networked RPCs must be called through the `rpc` procedures provided by nettyrpc, ie. `rpc("someRemoteProc", arg1, arg2, arg3)` or `rpc(conn, "someRemoteProc", arg1, arg2, arg3)`.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # nettyrpc
  Implements an RPC-like system for Nim
 
-nettyrpc is an RPC library built on top of the netty library, and sends data over a modified UDP connection that's capped at 250kb of in-flight data.  Netty performs packet ordering and packet resending like a TCP connection.  Check the netty library for more information about how netty utilizes UDP, and it's limitations.
+nettyrpc is a RPC module built on top of the netty library, and sends data over a modified UDP connection that's capped at 250kb of in-flight data.  Netty performs packet ordering and packet resending like a TCP connection, but it's all done over UDP.  Check the netty library for more information about how netty utilizes UDP, and it's limitations.
 
-nettyrpc can be set up to run authoritative and non-authoritative servers by the use of `{.networked.}` or `{.relayed.}` RPCs. 
+https://github.com/treeform/netty
 
-A relayed RPC is sent directly to the server, no server-side processing is done and the RPC is sent to every connected client on the server where it is processed client-side.  Relayed RPCs have a `isLocal` bool that can be used to control what the caller runs in a relayed procedure vs what the receivers runs.  Relayed procedures can be called like any other procedure.
+nettyrpc can be set up to run authoritative and non-authoritative servers by the use of `{.networked.}` or `{.relayed.}` procedures. 
 
-Networked RPCs are sent to the server where the server processes the data, and depending on how you write your server code, the server can forward the data to an individual client, all clients, or process the data server-side without any forwarding.  Networked RPCs must be called through the `rpc` procedures provided by nettyrpc.
+A relayed RPC is sent directly to the server, no server-side processing is done and the RPC is sent to every connected client on the server where it is processed client-side.  Relayed RPCs have a `isLocal` bool that can be used to control what the caller runs in a relayed procedure vs what the receivers run.  Unlike networked procedures, relayed procedures can be called like any other procedure.
+
+Networked RPCs are sent to the server where the server processes the data, and depending on how you write your server code, the server can forward the data to an individual client, all clients, or process the data server-side without any forwarding.  Networked RPCs must be called through the `rpc` procedures provided by nettyrpc, ie. `rpc("someRemoteProc", arg1, arg2, arg3)` or `rpc(conn, "someRemoteProc", arg1, arg2, arg3)`.
 
 Both relayed and networked RPCs contain a netty `Connection` object that represents the RPC caller's connection.  This is accessed through the `conn` variable that is automatically added to any `{.relayed.}` or `{.networked.}` procedures.
 
@@ -17,4 +19,69 @@ Mostly games, but any networked application that does not require a ton of throu
 
 ## Examples
 
-Check the examples folder in this repo for documented examples.
+Here is what a typical `{.relayed.}` procedure looks like on the client-side.
+
+```nim
+proc send(name, message: string) {.relayed.} =
+  if not isLocal:  # If remote client runs procedure
+    eraseLine()
+    echo fmt"{getClockStr()} {name} says: {message}"
+  else:  # If local client runs procedure.
+    eraseLine()
+    echo fmt"{getClockStr()} You said: {message}"
+```
+
+Remember that `{.relayed.}` procedures do not require any server-side RPCs to be defined, so we only need to modify our client's code.
+
+A `{.networked.}` procedure requires us to implement server-side RPCs so the server can process the request and dispatch RPCs manually.
+
+Here is a client with a `{.networked.}` procedure.  It attempts to run the `join` procedure located on the server, and the server then processes the message and calls the `welcome` procedure on all connected clients.
+
+```nim
+import netty, nettyrpc
+import std/[strutils, strformat]
+
+
+proc welcome(name: string, id: int) {.networked.} =
+  ## Display a welcome message.
+  echo fmt"{id}:{name} has joined the server"
+
+
+let client = newReactor()
+
+nettyrpc.client = client.connect("127.0.0.1", 1999)
+nettyrpc.reactor = client
+
+# Call the `join` procedure on the server with an argument representing our name.
+rpc("join", ("Bobby Bouche", 1))
+
+while true:
+  client.rpcTick()  # rpcTick handles calling/sending procedures
+```
+
+Here is the server code we need to handle the call to `join`, and then calling the `welcome` procedure on each connected client.
+
+```nim
+import netty, nettyrpc, os
+
+
+proc join(name: string, id: int) {.networked.} =
+  # Do server side logic, maybe we log the event or something like that.
+  rpc("welcome", (name, id))  # Call `welcome` procedure on all connected clients.
+  rpc(conn, "welcome", (name, id))  # Call `welcome` procedure on the client that called `join`.
+
+
+# listen for a connection on localhost port 1999
+var server = newReactor("127.0.0.1", 1999)
+
+# Set nettyrpc reactor to server.
+nettyrpc.reactor = server
+
+# main loop
+while true:
+  server.rpcTick(server=true)  # rpcTick handles dispatching of procedures.
+  for msg in server.messages:  # Display messages since last tick.
+    echo msg
+```
+
+Check the examples folder in this repo for the full documented examples.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nettyrpc
  Implements an RPC-like system for Nim
 
-nettyrpc is a RPC module built on top of the netty library, and sends data over a modified UDP connection that's capped at 250kb of in-flight data.  Netty performs packet ordering and packet resending like a TCP connection, but it's all done over UDP.  Check the netty library for more information about how netty utilizes UDP, and it's limitations.
+nettyrpc is a RPC module for game development.  nettyrpc is built on top of the netty library, and sends data over a modified UDP connection that's capped at 250k of in-flight data.  Netty performs packet ordering and packet resending like a TCP connection, but it's all done over UDP.  Check the netty library for more information about how netty utilizes UDP, and it's limitations.
 
 https://github.com/treeform/netty
 
@@ -11,11 +11,11 @@ A `{.relayed.}` RPC is sent directly to the server, no server-side processing is
 
 `{.networked.}` RPCs are sent to the server where the server processes the data, and depending on how you write your server code, the server can forward the data to an individual client, all clients, or process the data server-side without any forwarding.  Networked RPCs must be called through the `rpc` procedures provided by nettyrpc, ie. `rpc("someRemoteProc", (arg1, arg2, arg3))` or `rpc(conn, "someRemoteProc", (arg1, arg2, arg3))`.  It's important that your args are wrapped in a `tuple` when using the `rpc` procedures.
 
-Both relayed and networked RPCs contain a netty `Connection` object that represents the RPC caller's connection.  This is accessed through the `conn` variable that is automatically added to any `{.relayed.}` or `{.networked.}` procedures.
+Both relayed and networked RPCs contain [a netty `Connection` object](https://github.com/treeform/netty/blob/master/src/netty.nim#L52) that represents the RPC caller's connection.  This is accessed through the `conn` variable that is automatically added to any `{.relayed.}` or `{.networked.}` procedures.
 
 ## Uses
 
-Mostly games, but any networked application that does not require a ton of throughput.  UDP is not designed for throughput, however this library could be used to negotiate a TCP connection for larger data transfers.
+Mostly game developement, but any networked application that does not require a ton of throughput.  UDP is not designed for throughput, however this library could be used to negotiate a TCP connection for larger data transfers.
 
 ## Examples
 
@@ -38,7 +38,6 @@ A `{.networked.}` procedure requires us to implement server-side RPCs so the ser
 ### A Tiny Example
 
 Here is a client with a `{.networked.}` procedure.  It attempts to run the `join` procedure located on the server, and the server then processes the message and calls the `welcome` procedure on all connected clients.
-
 
 __client.nim__
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ nettyrpc can be set up to run authoritative and non-authoritative servers by the
 
 A `{.relayed.}` RPC is sent directly to the server, no server-side processing is done and the RPC is sent to every connected client on the server where it is processed client-side.  Relayed RPCs have a `isLocal` bool that can be used to control what the caller runs in a relayed procedure vs what the receivers run.  Unlike `{.networked.}` procedures, relayed procedures can be called like any other procedure.
 
-Networked RPCs are sent to the server where the server processes the data, and depending on how you write your server code, the server can forward the data to an individual client, all clients, or process the data server-side without any forwarding.  Networked RPCs must be called through the `rpc` procedures provided by nettyrpc, ie. `rpc("someRemoteProc", arg1, arg2, arg3)` or `rpc(conn, "someRemoteProc", arg1, arg2, arg3)`.
+`{.networked.}` RPCs are sent to the server where the server processes the data, and depending on how you write your server code, the server can forward the data to an individual client, all clients, or process the data server-side without any forwarding.  Networked RPCs must be called through the `rpc` procedures provided by nettyrpc, ie. `rpc("someRemoteProc", (arg1, arg2, arg3))` or `rpc(conn, "someRemoteProc", (arg1, arg2, arg3))`.  It's important that your arguments are contained within a `tuple`.
 
 Both relayed and networked RPCs contain a netty `Connection` object that represents the RPC caller's connection.  This is accessed through the `conn` variable that is automatically added to any `{.relayed.}` or `{.networked.}` procedures.
 
@@ -35,36 +35,45 @@ Remember that `{.relayed.}` procedures do not require any server-side RPCs to be
 
 A `{.networked.}` procedure requires us to implement server-side RPCs so the server can process the request and dispatch RPCs manually.
 
+### A Tiny Example
+
 Here is a client with a `{.networked.}` procedure.  It attempts to run the `join` procedure located on the server, and the server then processes the message and calls the `welcome` procedure on all connected clients.
+
+
+__client.nim__
 
 ```nim
 import netty, nettyrpc
 import std/[strutils, strformat]
 
-
+# Define our client-side RPC.
 proc welcome(name: string, id: int) {.networked.} =
   ## Display a welcome message.
   echo fmt"{id}:{name} has joined the server"
 
-
+# Set up nettyrpc to run as a client.
 let client = newReactor()
-
 nettyrpc.client = client.connect("127.0.0.1", 1999)
 nettyrpc.reactor = client
 
-# Call the `join` procedure on the server with an argument representing our name.
+# Call the `join` procedure on the server with an argument 
+# representing our name, along with an id.
 rpc("join", ("Bobby Bouche", 1))
 
 while true:
-  client.rpcTick()  # rpcTick handles calling/sending procedures
+  # rpcTick handles calling/sending procedures.  This must be called to send
+  # and receive RPCs.
+  client.rpcTick()  
 ```
 
 Here is the server code we need to handle the call to `join`, and then calling the `welcome` procedure on each connected client.
 
+__server.nim__
+
 ```nim
 import netty, nettyrpc, os
 
-
+# Define server-side RPC
 proc join(name: string, id: int) {.networked.} =
   # Do server side logic, maybe we log the event or something like that.
   rpc("welcome", (name, id))  # Call `welcome` procedure on all connected clients.
@@ -74,12 +83,12 @@ proc join(name: string, id: int) {.networked.} =
 # listen for a connection on localhost port 1999
 var server = newReactor("127.0.0.1", 1999)
 
-# Set nettyrpc reactor to server.
+# Set up nettyrpc as a server.
 nettyrpc.reactor = server
 
 # main loop
 while true:
-  server.rpcTick(server=true)  # rpcTick handles dispatching of procedures.
+  server.rpcTick(server=true)  # rpcTick handles dispatching of procedures. Must be called.
   for msg in server.messages:  # Display messages since last tick.
     echo msg
 ```

--- a/example/chatclient/client.nim
+++ b/example/chatclient/client.nim
@@ -16,7 +16,7 @@ proc getParams: (string, string, int) =
     of "name", "n":
       result[0] = val
 
-proc send(name, message: string){.networked.} =
+proc send(name, message: string) {.relayed.} =
   if not isLocal:
     eraseLine()
     echo fmt"{getClockStr()} {name} says: {message}"

--- a/example/chatclient/server.nim
+++ b/example/chatclient/server.nim
@@ -9,13 +9,15 @@ nettyrpc.reactor = server
 # main loop
 while true:
   server.rpcTick(server=true)  
+  for msg in server.messages:  # Display messages since last tick.
+    echo msg
+    
   # rpcTick(server=true) will automatically loop through messages
   # and dispatch/relay RPCs.  It's the equivelant to the following
   # relay code:
   #
   # for msg in server.messages:
-  #   echo msg
   #   for client in server.connections:
   #     if(msg.conn != client):
   #       server.send(client, msg.data)
-  sleep(30)
+  # sleep(30)

--- a/example/chatclient/server.nim
+++ b/example/chatclient/server.nim
@@ -1,14 +1,17 @@
-import netty, os
+import netty, nettyrpc, os
 
 # listen for a connection on localhost port 1999
 var server = newReactor("127.0.0.1", 1999)
 # main loop
 while true:
-  server.tick()
-  #We be relaying
-  for msg in server.messages:
-    echo msg
-    for client in server.connections:
-      if(msg.conn != client):
-        server.send(client, msg.data)
+  server.rpcTick(server=true)  
+  # rpcTick(server=true) will automatically loop through messages
+  # and dispatch/relay RPCs.  It's the equivelant to the following
+  # relay code:
+  #
+  # for msg in server.messages:
+  #   echo msg
+  #   for client in server.connections:
+  #     if(msg.conn != client):
+  #       server.send(client, msg.data)
   sleep(30)

--- a/example/chatclient/server.nim
+++ b/example/chatclient/server.nim
@@ -2,6 +2,10 @@ import netty, nettyrpc, os
 
 # listen for a connection on localhost port 1999
 var server = newReactor("127.0.0.1", 1999)
+
+# Set nettyrpc reactor to server.
+nettyrpc.reactor = server
+
 # main loop
 while true:
   server.rpcTick(server=true)  

--- a/example/pong/client.nim
+++ b/example/pong/client.nim
@@ -37,7 +37,7 @@ var
 
 proc lobbyFull: bool = otherID != 0
 
-proc join(a: uint32, name: string, isLeft = false){.networked.} =
+proc join(a: uint32, name: string, isLeft = false) {.relayed.} =
   if not isLocal:
     # Attempt to handshake
     if(a != otherID): shouldHandshake = true
@@ -45,22 +45,22 @@ proc join(a: uint32, name: string, isLeft = false){.networked.} =
     otherLeft = isLeft
     otherName = name
 
-proc changeState(gs: GameState){.networked.} =
+proc changeState(gs: GameState) {.relayed.} =
   if isLocal:
     currentState = gs
   else:
     otherState = gs
 
-proc updatePaddle(p: Paddle){.networked.} =
+proc updatePaddle(p: Paddle) {.relayed.} =
   if(not isLocal):
     for x in paddles.mitems:
       if(not x.local):
         x.y = p.y
 
-proc updateBall(inBall: Ball){.networked.} =
+proc updateBall(inBall: Ball) {.relayed.} =
   ball = inBall
 
-proc ballScored(leftScr, rightScr: int){.networked.} =
+proc ballScored(leftScr, rightScr: int) {.relayed.} =
   leftScore = leftScr
   rightScore = rightScr
 

--- a/example/pong/server.nim
+++ b/example/pong/server.nim
@@ -1,13 +1,20 @@
-import netty, os
+import netty, nettyrpc, os
 
 # listen for a connection on localhost port 1999
 var server = newReactor("127.0.0.1", 1999)
+
+nettyrpc.reactor = server
+
 # main loop
 while true:
-  server.tick()
-  #We be relaying
-  for msg in server.messages:
-    for client in server.connections:
-      if(msg.conn != client):
-        server.send(client, msg.data)
+  server.rpcTick(server=true)
+  # rpcTick(server=true) will automatically loop through messages
+  # and dispatch/relay RPCs.  It's the equivelant to the following
+  # relay code:
+  #
+  # for msg in server.messages:
+  #   echo msg
+  #   for client in server.connections:
+  #     if(msg.conn != client):
+  #       server.send(client, msg.data)
   sleep(30)

--- a/src/nettyrpc.nim
+++ b/src/nettyrpc.nim
@@ -1,4 +1,4 @@
-import std/[macros, strutils, macrocache, tables, hashes, sequtils]
+import std/[macros, macrocache, tables, hashes]
 import netty
 import nettyrpc/nettystream
 

--- a/src/nettyrpc.nim
+++ b/src/nettyrpc.nim
@@ -98,18 +98,18 @@ proc rpcTick*(sock: Reactor, server: bool = false) =
       managedEvents[managedId](managedBuff, conns[i])
       break  # buffer will be consumed so we don't need to keep looping.
 
-    # If there was no managed proc then check for relayed procs
-    # in case of client, and run the relay if the server is 
-    # the one running rpcTick.
+    if server:  # No need to check server for relayed procs since they don't exist
+      relay(relayedBuff.getBuffer, conns[i])
+      break  # buffer will be consumed so we don't need to keep looping.
+
+    # If there was no managed proc and we are client then check for relayed 
+    # procs and run them.
     let relayedId = block:
       var res: uint16
       relayedBuff.read res
       res
     if(relayedEvents[relayedId] != nil):
       relayedEvents[relayedId](relayedBuff, conns[i])
-      break  # buffer will be consumed so we don't need to keep looping.
-    elif(server == true):
-      relay(relayedBuff.getBuffer, conns[i])
       break  # buffer will be consumed so we don't need to keep looping.
     i += 1
 

--- a/src/nettyrpc.nim
+++ b/src/nettyrpc.nim
@@ -40,17 +40,17 @@ proc sendall*(message: var NettyStream) =
       reactor.send(conn, d)
     message.clear()
 
-template rpc*(conn: Connection, procName: string, vargs: varargs) =
+proc rpc*(conn: Connection, procName: string, vargs: tuple) =
   ## Send a rpc to a specific connection.
   sendBuffer.write(hash(procName))
-  for v in vargs:
+  for k, v in vargs.fieldPairs:
     sendBuffer.write(v)
   send(conn, sendBuffer)
 
-template rpc*(procName: string, vargs: varargs) =
+proc rpc*(procName: string, vargs: tuple) =
   ## Send a rpc to all connected clients.
   sendBuffer.write(hash(procName))
-  for v in vargs:
+  for k, v in vargs.fieldPairs:
     sendBuffer.write(v)
   sendall(sendBuffer)
 

--- a/src/nettyrpc.nim
+++ b/src/nettyrpc.nim
@@ -213,7 +213,8 @@ macro networked*(toNetwork: untyped): untyped =
   ## The Connection is the sender of the RPC.
   ## You can use the connection to call an RPC on that
   ## connection only via `rpc(conn, "some_func", a)`
-  ## or `conn.rpc("some_func", a)`
+  ## or `conn.rpc("some_func", a)`.  The Connection object
+  ## on the client-side will always represent the connection to the server.
   
   var (paramNames, paramNameType) = mapProcParams(toNetwork)
   var (recBody, sendBody, data, conn) = patchNodes(toNetwork, paramNames, paramNameType)
@@ -225,8 +226,7 @@ macro relayed*(toNetwork: untyped): untyped =
   ## it emits a proc(a: int, conn: Connection = Connection(), isLocal: static bool = false).
   ## Use `if isLocal` to diferentiate "sender" and "reciever" logic.
   ## Will always relay to the server the passed in data.
-  ## A netty Connection is provided to the proc so senders
-  ## can still be identified in relayed procedures.
+  ## Netty Connection object will always represent connection to server.
   
   var (paramNames, paramNameType) = mapProcParams(toNetwork)
   var (recBody, sendBody, data, conn) = patchNodes(toNetwork, paramNames, paramNameType, true)

--- a/src/nettyrpc.nim
+++ b/src/nettyrpc.nim
@@ -131,7 +131,6 @@ proc mapProcParams(toNetwork: NimNode): tuple[n: seq[NimNode], t: seq[(NimNode, 
             newCall(ident"typeOf", x[^1])
         paramNameType.add (ident, typ)
         paramNames.add ident
-  echo paramNameType
   (paramNames, paramNameType)
 
 proc patchNodes(toNetwork: NimNode, paramNames: var seq[NimNode], paramNameType: var seq[(NimNode, NimNode)], isRelayed: bool = false): tuple[recBody: NimNode, sendBody: NimNode, data: NimNode, conn: NimNode] =

--- a/src/nettyrpc.nim
+++ b/src/nettyrpc.nim
@@ -42,7 +42,7 @@ proc sendall*(message: var NettyStream) =
       reactor.send(conn, d)
     message.clear()
 
-proc writeHashedProcName(procName: Strings) =
+proc writeHashedProcName(procName: Strings) {.inline.} =
   ## Write the hashed procedure name to the send buffer.
   when procName.type is static string:
     const hashedName = hash(procName)

--- a/src/nettyrpc.nim
+++ b/src/nettyrpc.nim
@@ -40,14 +40,14 @@ proc sendall*(message: var NettyStream) =
       reactor.send(conn, d)
     message.clear()
 
-proc rpc*[T](conn: Connection, procName: string, vargs: varargs[T]) =
+template rpc*(conn: Connection, procName: string, vargs: varargs) =
   ## Send a rpc to a specific connection.
   sendBuffer.write(hash(procName))
   for v in vargs:
     sendBuffer.write(v)
   send(conn, sendBuffer)
 
-proc rpc*[T](procName: string, vargs: varargs[T]) =
+template rpc*(procName: string, vargs: varargs) =
   ## Send a rpc to all connected clients.
   sendBuffer.write(hash(procName))
   for v in vargs:

--- a/src/nettyrpc.nim
+++ b/src/nettyrpc.nim
@@ -1,4 +1,4 @@
-import std/[macros, strutils, macrocache]
+import std/[macros, strutils, macrocache, tables, hashes, sequtils]
 import netty
 import nettyrpc/nettystream
 
@@ -6,9 +6,10 @@ export nettystream
 
 type NettyRpcException = object of CatchableError
 
-var 
+var
   compEventCount{.compileTime.} = 0u16
-  events*: array[uint16, proc(data: var NettyStream)] ## Ugly method of holding procedures
+  relayedEvents*: array[uint16, proc(data: var NettyStream, conn: Connection)] ## Ugly method of holding procedures
+  managedEvents*: Table[Hash, proc(data: var NettyStream, conn: Connection)] ## Uglier method of holding procedures
   reactor*: Reactor
   client*: Connection
   sendBuffer* = NettyStream()


### PR DESCRIPTION
This would update the `{.networked.}` pragma to create boilerplate for supporting server-side RPCs, while adding a `{.relayed.}` pragma that creates boilerplate for supporting client-side RPCs.  `networked` RPCs are called via the `rpc` procedures and `relayed` RPCs are called like normal procedures.

`rpcTick` is set up to be called client-side and server-side, whether the user is using `relayed` or `networked` procedures, this should be called on the server and client to process messages/dispatch local procedure calls.

`networked` and `relayed` procedures gain access to the netty `Connection` object associated with the remote procedure call through the `conn` variable.

Any project that currently uses nettyrpc can be updated by switching out any `{.networked.}` pragma with the `{.relayed.}` pragma.

Authoritative server examples will follow. 